### PR TITLE
Provide an easier way to use tape-promise.

### DIFF
--- a/tape.js
+++ b/tape.js
@@ -1,0 +1,3 @@
+// tape is not a dependency of test-promise and must therefore be
+// added as a dependency by the user project.
+module.exports = require('./')(require('tape'))


### PR DESCRIPTION
The user can simply do:

``` js
import test from 'tape-promise/tape'
```
