### PR TITLE
Tape compatibility (argument swapping, options, and tape.only)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: node_js
 before_install:
   - "npm install npm -g"
 node_js:
+  - 9.0
+  - 8.0
   - 7.0
   - 6.0
-  - 5.0
-  - 4.0
 sudo: false

--- a/index.babel.js
+++ b/index.babel.js
@@ -1,13 +1,35 @@
 import onetime from 'onetime'
 import isPromise from 'is-promise'
 
+// From: https://github.com/substack/tape/blob/17276d7473f9d98e37bab47ebdddf74ca1931f43/lib/test.js#L24
+// Modified only for linting
+const getTestArgs = function (name_, opts_, cb_) {
+  let name = '(anonymous)'
+  let opts = {}
+  let cb
+
+  for (var i = 0; i < arguments.length; i++) {
+    var arg = arguments[i]
+    var t = typeof arg
+    if (t === 'string') {
+      name = arg
+    } else if (t === 'object') {
+      opts = arg || opts
+    } else if (t === 'function') {
+      cb = arg
+    }
+  }
+  return { name: name, opts: opts, cb: cb }
+}
+
 export default function tapePromiseFactory (tapeTest) {
-  function testPromise (description, testFn) {
-    tapeTest(description, function (t) {
+  function testPromise (...args) {
+    const { name, opts, cb } = getTestArgs(...args)
+    tapeTest(name, opts, function (t) {
       t.end = onetime(t.end)
       process.once('unhandledRejection', t.end)
       try {
-        const p = testFn(t)
+        const p = cb(t)
         if (isPromise(p)) p.then(() => t.end(), t.end)
       } catch (e) {
         t.end(e)
@@ -19,7 +41,11 @@ export default function tapePromiseFactory (tapeTest) {
 
   Object.keys(tapeTest).forEach((key) => {
     if (typeof tapeTest[key] !== 'function') return
-    testPromise[key] = tapeTest[key]
+    if (key === 'only') {
+      testPromise[key] = tapePromiseFactory(tapeTest[key])
+    } else {
+      testPromise[key] = tapeTest[key]
+    }
   })
 
   return testPromise

--- a/index.es5.js
+++ b/index.es5.js
@@ -3,6 +3,9 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
+
 exports.default = tapePromiseFactory;
 
 var _onetime = require('onetime');
@@ -15,13 +18,39 @@ var _isPromise2 = _interopRequireDefault(_isPromise);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
+// From: https://github.com/substack/tape/blob/17276d7473f9d98e37bab47ebdddf74ca1931f43/lib/test.js#L24
+// Modified only for linting
+var getTestArgs = function getTestArgs(name_, opts_, cb_) {
+  var name = '(anonymous)';
+  var opts = {};
+  var cb = void 0;
+
+  for (var i = 0; i < arguments.length; i++) {
+    var arg = arguments[i];
+    var t = typeof arg === 'undefined' ? 'undefined' : _typeof(arg);
+    if (t === 'string') {
+      name = arg;
+    } else if (t === 'object') {
+      opts = arg || opts;
+    } else if (t === 'function') {
+      cb = arg;
+    }
+  }
+  return { name: name, opts: opts, cb: cb };
+};
+
 function tapePromiseFactory(tapeTest) {
-  function testPromise(description, testFn) {
-    tapeTest(description, function (t) {
+  function testPromise() {
+    var _getTestArgs = getTestArgs.apply(undefined, arguments),
+        name = _getTestArgs.name,
+        opts = _getTestArgs.opts,
+        cb = _getTestArgs.cb;
+
+    tapeTest(name, opts, function (t) {
       t.end = (0, _onetime2.default)(t.end);
       process.once('unhandledRejection', t.end);
       try {
-        var p = testFn(t);
+        var p = cb(t);
         if ((0, _isPromise2.default)(p)) p.then(function () {
           return t.end();
         }, t.end);
@@ -35,7 +64,11 @@ function tapePromiseFactory(tapeTest) {
 
   Object.keys(tapeTest).forEach(function (key) {
     if (typeof tapeTest[key] !== 'function') return;
-    testPromise[key] = tapeTest[key];
+    if (key === 'only') {
+      testPromise[key] = tapePromiseFactory(tapeTest[key]);
+    } else {
+      testPromise[key] = tapeTest[key];
+    }
   });
 
   return testPromise;

--- a/tests/only-promise.test.js
+++ b/tests/only-promise.test.js
@@ -1,0 +1,13 @@
+import tape from 'tape'
+import _test from '../'
+const test = _test(tape)
+
+const delay = (time) => new Promise((resolve) => setTimeout(resolve, time))
+
+test.only('ensure that promise-based test.only works', (t) => {
+  return delay(100).then(() => t.true(true))
+})
+
+test('this should never run', (t) => {
+  t.fail()
+})

--- a/tests/only.test.js
+++ b/tests/only.test.js
@@ -1,0 +1,12 @@
+import tape from 'tape'
+import _test from '../'
+const test = _test(tape)
+
+test.only('ensure that regular test.only works', (t) => {
+  t.true(true)
+  t.end()
+})
+
+test('this should never run', (t) => {
+  t.fail()
+})

--- a/tests/regular.test.js
+++ b/tests/regular.test.js
@@ -6,3 +6,18 @@ test('ensure that regular test functions still work', (t) => {
   t.true(true)
   t.end()
 })
+
+test('ensure that regular test functions with options still work', {}, (t) => {
+  t.true(true)
+  t.end()
+})
+
+test((t) => {
+  t.true('ensure that anonymous test functions work')
+  t.end()
+}, 'ensure that regular test functions with swapped args still work', {})
+
+test((t) => {
+  t.true('ensure that anonymous test functions work')
+  t.end()
+})


### PR DESCRIPTION
Tape allows you to swap arguments however you want. Currently there is no way to include options at all. This fixes that. In addition, the wrapped `tape.only` function acts like a regular `tape` function. This fixes that too.