### PR TITLE
Fix t.plan()

### DIFF
--- a/index.babel.js
+++ b/index.babel.js
@@ -27,14 +27,20 @@ export default function tapePromiseFactory (tapeTest) {
     const { name, opts, cb } = getTestArgs(...args)
     tapeTest(name, opts, function (t) {
       t.end = onetime(t.end)
+
+      let plan = false
+      const setPlan = () => { plan = true }
+      t.once('plan', setPlan)
+
       process.once('unhandledRejection', t.end)
       try {
         const p = cb(t)
-        if (isPromise(p)) p.then(() => t.end(), t.end)
+        if (isPromise(p) && !plan) p.then(() => t.end(), t.end)
       } catch (e) {
         t.end(e)
       } finally {
         process.removeListener('unhandledRejection', t.end)
+        t.removeListener('plan', setPlan)
       }
     })
   }

--- a/tests/async.test.js
+++ b/tests/async.test.js
@@ -9,3 +9,12 @@ test('ensure async works', async (t) => {
   t.true(true)
   t.end()
 })
+
+test('plan should work when using async', async (t) => {
+  t.plan(2)
+  delay(100)
+    .then(() => {
+      t.true(true)
+      delay(100).then(() => t.true(true))
+    })
+})


### PR DESCRIPTION
When using an async function as the test callback, any asynchronous 
assertions that didn't use await (callbacks or .then) wouldn't be waited 
for when using t.plan as expected

The new behavior more closely mirrors tape, and I think it's what would always be expected when using tape-promise with an async function.