### PR TITLE
Use object shorthand for properties

### DIFF
--- a/index.babel.js
+++ b/index.babel.js
@@ -19,7 +19,7 @@ const getTestArgs = function (name_, opts_, cb_) {
       cb = arg
     }
   }
-  return { name: name, opts: opts, cb: cb }
+  return { name, opts, cb }
 }
 
 function registerNewAssertions (Test) {


### PR DESCRIPTION
This rule is on its way into the latest Standard ☺️

ref: https://github.com/standard/eslint-config-standard/pull/166

Compatibility: This syntax is compatible with Node >=4, this modules requirement is higher ✅ 

-----

I did not update `index.compiled.js` since it seems like you do that in the release commits, let me know if you want me to do it ☺️ 